### PR TITLE
Put GDIPlus Initialization Into It's Own Class

### DIFF
--- a/gdiplusinitialize.ixx
+++ b/gdiplusinitialize.ixx
@@ -1,0 +1,32 @@
+module;
+
+#include <windows.h>
+#include <gdiplus.h>
+
+export module gdiplusinitialize;
+
+using namespace Gdiplus;
+#pragma comment (lib,"Gdiplus.lib")
+
+export class gdiplusinitialize
+{
+public:
+   gdiplusinitialize();
+   ~gdiplusinitialize();
+
+private:
+   GdiplusStartupInput _gdiplusStartupInput;
+
+   ULONG_PTR           _gdiplusToken;
+};
+
+gdiplusinitialize::gdiplusinitialize()
+{
+   // Initialize GDI+.
+   GdiplusStartup(&_gdiplusToken, &_gdiplusStartupInput, NULL);
+}
+
+gdiplusinitialize::~gdiplusinitialize()
+{
+   GdiplusShutdown(_gdiplusToken);
+}

--- a/image.ixx
+++ b/image.ixx
@@ -28,8 +28,7 @@ module;
 
 export module image;
 
-using namespace Gdiplus;
-#pragma comment (lib,"Gdiplus.lib")
+import gdiplusinitialize;
 
 using namespace Gdiplus;
 
@@ -51,15 +50,9 @@ bool SaveImage(const std::wstring& filename, ImageEncondings enconding, int imag
 /// <param name="imageData">Image data buffer.</param>
 export void CreateImage(const std::wstring& filename, ImageEncondings enconding, int imageWidth, int imageHeight, BYTE* imageData)
 {
-    GdiplusStartupInput gdiplusStartupInput;
-    ULONG_PTR           gdiplusToken;
-
-    // Initialize GDI+.
-    GdiplusStartup(&gdiplusToken, &gdiplusStartupInput, NULL);
+   gdiplusinitialize GdiPlus;
 
     SaveImage(filename, enconding, imageWidth, imageHeight, imageData);
-
-    GdiplusShutdown(gdiplusToken);
 }
 
 /// <summary>

--- a/ppm2png.sln
+++ b/ppm2png.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31911.196
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ppm2png", "ppm2png.vcxproj", "{7A747D4E-C656-4053-8D88-46414525ACB8}"
 EndProject

--- a/ppm2png.vcxproj
+++ b/ppm2png.vcxproj
@@ -152,6 +152,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="gdiplusinitialize.ixx" />
     <ClCompile Include="image.ixx" />
     <ClCompile Include="main.ixx" />
   </ItemGroup>

--- a/ppm2png.vcxproj.filters
+++ b/ppm2png.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClCompile Include="main.ixx">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="gdiplusinitialize.ixx">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Readme.md" />


### PR DESCRIPTION
## Introduction

I was basically just trying out modules some with you repo.  If interested these are the changes I did.  I don't know much yet with modules.

## Details

I did re-save the `.sln` solution file because on my machine it opened in VS2019 instead of VS2022.

Instead of calling "Startup" and "Shutdown", I put those into a type and the destructor will call shutdown on my behalf.  It doesn't matter to me the capitalization of the class, and doesn't matter to me the syntax for member variables.  You can take it, change it, etc all you want.

I think I would have put the GdiPlus initialization in `main` so it is initialized for the duration of the program.  But I kept the existing behavior.

There were `2` lines that used the `Gdiplus` namespace in case it looks like I removed it.

## Testing Notes

I used the sample `.ppm` file and looks like it worked OK:
![image](https://user-images.githubusercontent.com/3475163/145640445-cdbdc67b-ca6b-455a-9b70-c9cf73d4140f.png)

Hope that helps! :smiley: