### PR TITLE
Bring C# size to 2 MB

### DIFF
--- a/csharp/ImageWriter.cs
+++ b/csharp/ImageWriter.cs
@@ -17,6 +17,7 @@
  */
 
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
 
 
@@ -36,10 +37,12 @@ public static class ImageWriter
     /// <param name="height">The image height in pixels.</param>
     public static void SaveImage(string filename, ReadOnlySpan<byte> buffer, int width, int height)
     {
-        using var image = Image.LoadPixelData<Rgb24>(buffer, width, height);
-        using var stream = new System.IO.FileStream(filename, FileMode.Create);
-        var pngEncoder = new SixLabors.ImageSharp.Formats.Png.PngEncoder() {
-             ColorType = SixLabors.ImageSharp.Formats.Png.PngColorType.Rgb
+        // Pass custom Configuration to avoid loading all default formats.
+        using var image = Image.LoadPixelData<Rgb24>(new(), buffer, width, height);
+        using var stream = new FileStream(filename, FileMode.Create);
+        var pngEncoder = new PngEncoder()
+        {
+            ColorType = PngColorType.Rgb
         };
 
         image.SaveAsPng(stream, pngEncoder);

--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -20,7 +20,7 @@ using static ppm2png.ImageWriter;
 
 if (args.Length < 2)
 {
-    string filename = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+    string filename = Path.GetFileName(Environment.ProcessPath!);
     Console.WriteLine($"Missing arguments:\n\n {filename}.exe ppm-filename png-filename\n");
     return 1;
 }

--- a/csharp/ppm2png.csproj
+++ b/csharp/ppm2png.csproj
@@ -5,15 +5,12 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RestoreAdditionalProjectSources>https://www.myget.org/F/sixlabors/api/v3/index.json</RestoreAdditionalProjectSources>
+    <RestoreAdditionalProjectSources>https://f.feedz.io/sixlabors/sixlabors/nuget/index.json</RestoreAdditionalProjectSources>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <TrimmableAssembly Include="SixLabors.ImageSharp" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2-alpha.0.38"/>
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
* Use ImageSharp that has the fix to the issue that included JPG/WEBP/etc. support even though one only wanted PNG
* Do not use `System.Diagnostics.Process` just to get `ProcessPath`. It's a lot more size (and typing).
* Set `InvariantGlobalization` to true (this is the default for `dotnet new console --aot` in .NET 8.

One could also set `<OptimizationPreference>Size</OptimizationPreference>` for extra savings.